### PR TITLE
Added NortheastPHP 2017's Code of Conduct

### DIFF
--- a/data/northeast-php-2017.txt
+++ b/data/northeast-php-2017.txt
@@ -8,6 +8,6 @@ state:           Prince Edward Island
 country:         Canada
 topics:          PHP
 languages:       English
-code_of_conduct: 
+code_of_conduct: http://2016.northeastphp.org/code-of-conduct/
 twitter:         NEPHP
 facebook:        


### PR DESCRIPTION
This was in the same place as 2016's Code of Conduct, not sure why this was missed. Linked in the footer of the site.