### PR TITLE
Add FOSDEM PGDay to list of events

### DIFF
--- a/data/events/fosdem-pgday-2017.txt
+++ b/data/events/fosdem-pgday-2017.txt
@@ -1,0 +1,16 @@
+name:            FOSDEM PGDay
+url:             https://2017.fosdempgday.org/
+start_date:      2017-02-03
+end_date:        2017-02-03
+cfp_date:        2016-11-13
+city:            Brussels
+state:
+country:         Belgium
+topics:          PostgreSQL
+languages:       English
+code_of_conduct: https://2017.fosdempgday.org/codeofconduct/
+twitter:         pgconfeu
+facebook:
+accessibility:
+diversitytickets:
+youtube:


### PR DESCRIPTION
Event entry for FOSDEM PGDay 2017, a one day event held in conjunction (but not affiliated) with FOSDEM.