### PR TITLE
Add historic PGConf.EU events

### DIFF
--- a/data/events/pgconfeu-2012.txt
+++ b/data/events/pgconfeu-2012.txt
@@ -1,0 +1,16 @@
+name:            PGConf.EU 2012
+url:             http://2012.pgconf.eu/
+start_date:      2012-10-23
+end_date:        2012-10-26
+cfp_date:
+city:            Prague
+state:           
+country:         Czech Republic
+topics:          PostgreSQL, Databases
+languages:       English
+code_of_conduct:
+twitter:         pgconfeu
+facebook:        PGConf.EU
+accessibility:   
+diversitytickets:
+youtube:          

--- a/data/events/pgconfeu-2013.txt
+++ b/data/events/pgconfeu-2013.txt
@@ -1,0 +1,16 @@
+name:            PGConf.EU 2013
+url:             http://2013.pgconf.eu/
+start_date:      2013-10-29
+end_date:        2013-11-01
+cfp_date:
+city:            Dublin
+state:           
+country:         Ireland
+topics:          PostgreSQL, Databases
+languages:       English
+code_of_conduct:
+twitter:         pgconfeu
+facebook:        PGConf.EU
+accessibility:   
+diversitytickets:
+youtube:          

--- a/data/events/pgconfeu-2014.txt
+++ b/data/events/pgconfeu-2014.txt
@@ -1,0 +1,16 @@
+name:            PGConf.EU 2014
+url:             http://2014.pgconf.eu/
+start_date:      2014-10-21
+end_date:        2014-10-24
+cfp_date:        2014-07-24
+city:            Madrid
+state:           
+country:         Spain
+topics:          PostgreSQL, Databases
+languages:       English
+code_of_conduct: http://2014.pgconf.eu/codeofconduct/
+twitter:         pgconfeu
+facebook:        PGConf.EU
+accessibility:   
+diversitytickets:
+youtube:          

--- a/data/events/pgconfeu-2015.txt
+++ b/data/events/pgconfeu-2015.txt
@@ -1,0 +1,16 @@
+name:            PGConf.EU 2015
+url:             http://2015.pgconf.eu/
+start_date:      2015-10-27
+end_date:        2015-10-30
+cfp_date:        2015-08-07
+city:            Vienna
+state:           
+country:         Austria
+topics:          PostgreSQL, Databases
+languages:       English
+code_of_conduct: http://2015.pgconf.eu/codeofconduct/
+twitter:         pgconfeu
+facebook:        PGConf.EU
+accessibility:   
+diversitytickets:
+youtube:          

--- a/data/events/pgconfeu-2016.txt
+++ b/data/events/pgconfeu-2016.txt
@@ -1,0 +1,16 @@
+name:            PGConf.EU 2016
+url:             http://2016.pgconf.eu/
+start_date:      2016-11-01
+end_date:        2016-11-04
+cfp_date:        2016-08-07
+city:            Tallinn
+state:           
+country:         Estonia
+topics:          PostgreSQL, Databases
+languages:       English
+code_of_conduct: http://2016.pgconf.eu/codeofconduct/
+twitter:         pgconfeu
+facebook:        PGConf.EU
+accessibility:   
+diversitytickets:
+youtube:          


### PR DESCRIPTION
The conference has been going for longer, but add some of the past PostgreSQL Conference Europe events.