### PR TITLE
Put custom js in static file

### DIFF
--- a/conf/templates/incl/scripts.html
+++ b/conf/templates/incl/scripts.html
@@ -1,24 +1,4 @@
 <script src="//code.jquery.com/jquery-3.1.1.min.js"></script>
 <script src="//cdn.datatables.net/1.10.12/js/jquery.dataTables.min.js"></script>
 <script src="//cdn.datatables.net/responsive/2.1.0/js/dataTables.responsive.min.js"></script>
-<script>
- $(function () {
-   [$('#conferences'), $('#earlier')].forEach(function (table) {
-     table.DataTable({
-       autoWidth: false,
-       columnDefs: [
-         { responsivePriority: 1, targets: -2 }, /* event title */
-         { responsivePriority: 2, targest: 0  }, /* start date */
-         { responsivePriority: 3, targets: -1 }  /* event location */
-       ],
-       pageLength: 50,
-       responsive: true
-     });
-   });
-   $('#topics').DataTable({
-     autoWidth: false,
-     pageLength: 25,
-     responsive: true
-   });
- });
-</script>
+<script src="/app.js"></script>

--- a/src/app.js
+++ b/src/app.js
@@ -1,0 +1,19 @@
+$(function () {
+  [$('#conferences'), $('#earlier')].forEach(function (table) {
+    table.DataTable({
+      autoWidth: false,
+      columnDefs: [
+        { responsivePriority: 1, targets: -2 }, /* event title */
+        { responsivePriority: 2, targest: 0  }, /* start date */
+        { responsivePriority: 3, targets: -1 }  /* event location */
+      ],
+      pageLength: 50,
+      responsive: true
+    });
+  });
+  $('#topics').DataTable({
+    autoWidth: false,
+    pageLength: 25,
+    responsive: true
+  });
+});


### PR DESCRIPTION
Avoid re-downloading custom dataTables js (also increasing size and load time) by putting it in its own file.